### PR TITLE
Worker name now showing

### DIFF
--- a/pool_templates/zilfarm.json
+++ b/pool_templates/zilfarm.json
@@ -17,7 +17,7 @@
                 "pass": "x",
                 "port": "5000/api",
                 "server": "zil://%URL_HOST%",
-                "template": "%WAL%.%WORKER_NAME%",
+                "template": "%WAL%.miner",
                 "user_config": "\"--work-timeout\" = \"7200\"\n\"--retry-delay\" = \"10000\"\n\"--report-hr\" = \"1\"\n\"--farm-retries\" = \"20\""
             }
         }


### PR DESCRIPTION
The name of the worker was not showing in the pool. Changed manually to a generic name.