### PR TITLE
wattpool: add SSL/TLS URL for ballz.wattpool.net

### DIFF
--- a/pool_templates/wattpool.json
+++ b/pool_templates/wattpool.json
@@ -166,6 +166,9 @@
                 "geo": "POOL",
                 "urls": [
                     "ballz.wattpool.net:9009"
+                ],
+                "ssl_urls": [
+                    "ballz.wattpool.net:9008"
                 ]
             }
         ],


### PR DESCRIPTION
* add SSL/TLS URL for ballz.wattpool.net