### PR TITLE
Update BBQDroid pool to use GeoDNS mining address

### DIFF
--- a/pool_templates/bbqdroid.json
+++ b/pool_templates/bbqdroid.json
@@ -10,12 +10,12 @@
     "coin": "VTC",
     "servers": [
       {
-        "geo": "Canada (EAST)",
-        "urls": ["stratum+tcp://bbqdroid.org:10001"]
+        "geo": "NA / EU",
+        "urls": ["stratum+tcp://mining.bbqdroid.org:10001"]
       },
       {
-        "geo": "Canada (EAST) - SOLO",
-        "urls": ["stratum+tcp://bbqdroid.org:20001"]
+        "geo": "NA / EU - SOLO",
+        "urls": ["stratum+tcp://mining.bbqdroid.org:20001"]
       }
     ],
     "miners": {


### PR DESCRIPTION
The new mining address will automatically select the best server
for you if you are mining from the United-States, Canada or Europe