### PR TITLE
bzminer fix for OLHASH

### DIFF
--- a/prototypes.json
+++ b/prototypes.json
@@ -1283,7 +1283,9 @@
             "tls": "1",
             "url": "%URL%",
             "algo": "olhash",
-            "template": "%WAL%.%WORKER_NAME%"
+            "template": "%WAL%",
+            "worker": "%WORKER_NAME%"
+            
         }
     }
 }


### PR DESCRIPTION
seems like worker name was used to login rather than wallet address