### PR TITLE
Update extremehash.json

### DIFF
--- a/pool_templates/extremehash.json
+++ b/pool_templates/extremehash.json
@@ -13,7 +13,7 @@
             {
                 "geo": "Europe",
                 "urls": [
-                     "eu-ol.extremehash.net:3141"
+                     "eu-ol.extremehash.net:3443"
                 ],
                 "ssl_urls": [
                      "eu-ol.extremehash.net:3443"
@@ -22,7 +22,7 @@
             {
                 "geo": "USA",
                 "urls": [
-                    "us.extremehash.net:3141"
+                    "us.extremehash.net:3443"
                 ],
                 "ssl_urls": [
                     "us.extremehash.net:3443"


### PR DESCRIPTION
always use ssl, as tcp tens to get ddos attacks, miners default config will always use ssl , both for bzminer and olminer fork