### PR TITLE
[FIX] Phoenixminer syntax

### DIFF
--- a/pool_templates/zetpool.json
+++ b/pool_templates/zetpool.json
@@ -36,7 +36,7 @@
 		},
 		"phoenixminer": {
 		    "url": "POOL: %URL%, WALLET: %WAL%, WORKER: %WORKER_NAME%, PSW: x",
-		    "user_config": "-coin %COIN% -stales 0 -clKernel 0"
+		    "user_config": "-coin %COIN% -stales 0"
 		},
 		"bminer": {
 		    "url": "%URL%",

--- a/pool_templates/zetpool.json
+++ b/pool_templates/zetpool.json
@@ -35,8 +35,8 @@
 		    "template": "%WAL%.%WORKER_NAME%"
 		},
 		"phoenixminer": {
-		    "url": "POOL: %URL%, WALLET: %WAL% WORKER: %WORKER_NAME%, PSW: x",
-		    "user_config": "-coin %COIN% -stales 0"
+		    "url": "POOL: %URL%, WALLET: %WAL%, WORKER: %WORKER_NAME%, PSW: x",
+		    "user_config": "-coin %COIN% -stales 0 -clKernel 0"
 		},
 		"bminer": {
 		    "url": "%URL%",


### PR DESCRIPTION
Added missing comma.
Force generic kernel to avoid "Unable to prepare kernels: clCreatekernel (-46)" error.