### PR TITLE
new whalesburg.com pool setup

### DIFF
--- a/pool_templates/whalesburg.json
+++ b/pool_templates/whalesburg.json
@@ -11,7 +11,7 @@
         "coin": "ETH",
         "servers": [
             {
-                "geo": "World - GeoDNS proximity routing",
+                "geo": "World - GeoDNS routing",
                 "urls": [
                     "pool.whalesburg.com:4000"
                 ],
@@ -20,7 +20,7 @@
                 ]
             },
             {
-                "geo": "World - GeoDNS proximity routing || lowDIFF",
+                "geo": "World - GeoDNS routing || lowDIFF",
                 "urls": [
                     "pool.whalesburg.com:4001"
                 ],
@@ -73,7 +73,7 @@
         "coin": "XMR",
         "servers": [
             {
-                "geo": "World - GeoDNS proximity routing",
+                "geo": "World - GeoDNS routing",
                 "urls": [
                     "pool.whalesburg.com:4100"
                 ],
@@ -108,7 +108,7 @@
         "coin": "ERG",
         "servers": [
             {
-                "geo": "World - GeoDNS proximity routing",
+                "geo": "World - GeoDNS routing",
                 "urls": [
                     "pool.whalesburg.com:4200"
                 ],

--- a/pool_templates/whalesburg.json
+++ b/pool_templates/whalesburg.json
@@ -4,54 +4,139 @@
             "name": "Whalesburg",
             "url": "https://whalesburg.com",
             "fee": 1,
-            "type": "SMPPS+"
-        }
-    },
-    {
-        "coin": "Whalesburg-Ethash",
-        "servers": [
-            {
-                "geo": "Europe",
-                "urls": [
-                    "eu1.whalesburg.com:8082",
-                    "eu2.whalesburg.com:8082"
-                ],
-                "ssl_urls": [
-                    "eu1.whalesburg.com:7777",
-                    "eu2.whalesburg.com:7777"
-                ]
-            }
-        ],
-        "miners": {
-            "_prototype": "miners_ethash",
-            "claymore": {
-                "epools_tpl": "POOL: %URL%, WALLET: %WAL%, WORKER: %WORKER_NAME%, ALLPOOLS: 1, ALLCOINS -1, -GSER 2"
-            },
-            "tt-miner": {
-                "url": "stratum1+tcp://%URL%"
-            }
+            "type": "PPLNS"
         }
     },
     {
         "coin": "ETH",
         "servers": [
             {
-                "geo": "Europe",
+                "geo": "World - GeoDNS proximity routing",
                 "urls": [
-                    "eu1.whalesburg.com:8082",
-                    "eu2.whalesburg.com:8082"
+                    "pool.whalesburg.com:4000"
                 ],
                 "ssl_urls": [
-                    "eu1.whalesburg.com:7777",
-                    "eu2.whalesburg.com:7777"
+                    "pool.whalesburg.com:4000"
+                ]
+            },
+            {
+                "geo": "World - GeoDNS proximity routing || lowDIFF",
+                "urls": [
+                    "pool.whalesburg.com:4001"
+                ],
+                "ssl_urls": [
+                    "pool.whalesburg.com:4001"
+                ]
+            },
+            {
+                "geo": "EU",
+                "urls": [
+                    "eu.whalesburg.com:4000"
+                ],
+                "ssl_urls": [
+                    "eu.whalesburg.com:4000"
+                ]
+            },
+            {
+                "geo": "EU || lowDIFF",
+                "urls": [
+                    "eu.whalesburg.com:4001"
+                ],
+                "ssl_urls": [
+                    "eu.whalesburg.com:4001"
+                ]
+            },
+            {
+                "geo": "ASIA",
+                "urls": [
+                    "asia.whalesburg.com:4000"
+                ],
+                "ssl_urls": [
+                    "asia.whalesburg.com:4000"
+                ]
+            },
+            {
+                "geo": "ASIA || lowDIFF",
+                "urls": [
+                    "asia.whalesburg.com:4001"
+                ],
+                "ssl_urls": [
+                    "asia.whalesburg.com:4001"
                 ]
             }
         ],
         "miners": {
-            "_prototype": "miners_ethash_4g",
-            "tt-miner": {
-                "url": "stratum1+tcp://%URL%"
+            "_prototype": "miners_ethash"
+        }
+    },
+    {
+        "coin": "XMR",
+        "servers": [
+            {
+                "geo": "World - GeoDNS proximity routing",
+                "urls": [
+                    "pool.whalesburg.com:4100"
+                ],
+                "ssl_urls": [
+                    "pool.whalesburg.com:4100"
+                ]
+            },
+            {
+                "geo": "EU",
+                "urls": [
+                    "eu.whalesburg.com:4100"
+                ],
+                "ssl_urls": [
+                    "eu.whalesburg.com:4100"
+                ]
+            },
+            {
+                "geo": "ASIA",
+                "urls": [
+                    "asia.whalesburg.com:4100"
+                ],
+                "ssl_urls": [
+                    "asia.whalesburg.com:4100"
+                ]
             }
+        ],
+        "miners": {
+            "_prototype": "miners_randomx"
+        }
+    },
+    {
+        "coin": "ERG",
+        "servers": [
+            {
+                "geo": "World - GeoDNS proximity routing",
+                "urls": [
+                    "pool.whalesburg.com:4200"
+                ],
+                "ssl_urls": [
+                    "pool.whalesburg.com:4200"
+                ]
+            },
+            {
+                "geo": "EU",
+                "urls": [
+                    "eu.whalesburg.com:4200"
+                ],
+                "ssl_urls": [
+                    "eu.whalesburg.com:4200"
+                ]
+            },
+            {
+                "geo": "ASIA",
+                "urls": [
+                    "asia.whalesburg.com:4200"
+                ],
+                "ssl_urls": [
+                    "asia.whalesburg.com:4200"
+                ]
+            }
+        ],
+        "miners": {
+		    "_prototype": "miners_autolykos2"
         }
     }
 ]


### PR DESCRIPTION
Dar HiveOS Team, 
we, the new team behind whalesburg.com finally managed to get our pool (re)launched.
Our pool has an auto TLS feature. When a connection request is made, our pool checks for a TLS header. If none is present, the pool fallbacks to unencrypted connections. That's the reason why SSL and non SSL connections can share the same TCP port.

For the moment we have a portforwarding  from 7777 to 4000 to support the old configuration parameters. 

Kind reagrds

ei8ht