### PR TITLE
Kryptex Pool: Add ALPH, add BTC PPS+, add SOLO

### DIFF
--- a/pool_templates/kryptex.json
+++ b/pool_templates/kryptex.json
@@ -4,7 +4,7 @@
             "name": "Kryptex Pool",
             "url": "https://pool.kryptex.com/",
             "fee": 1,
-            "type": "PPS+, PROP"
+            "type": "PPS+, PROP, SOLO"
         }
     },
     {
@@ -243,6 +243,40 @@
         ],
         "miners": {
             "_prototype": "miners_octopus"
+        }
+    },
+    {
+        "coin": "ALPH",
+        "servers": [
+            {
+                "geo": "Global",
+                "urls": [
+                    "alph.kryptex.network:7777"
+                ],
+                "ssl_urls": [
+                    "alph.kryptex.network:8888"
+                ]
+            }
+        ],
+        "miners": {
+            "_prototype": "miners_alephium"
+        }
+    },
+    {
+        "coin": "BTC",
+        "servers": [
+            {
+                "geo": "Global",
+                "urls": [
+                    "btc.kryptex.network:7777"
+                ]
+            }
+        ],
+        "miners": {
+            "asicminer": {
+                "url": "stratum+tcp://%URL%",
+                "template": "%WAL%.%WORKER_NAME%"
+            }
         }
     }
 ]


### PR DESCRIPTION
Hello!

We've launched new BTC pool, Alephium pool and also now offer SOLO mining capabilities.