### PR TITLE
Fix XelPool with OneZeroMiner v1.3.3

### DIFF
--- a/pool_templates/xelpool.json
+++ b/pool_templates/xelpool.json
@@ -34,7 +34,7 @@
         "url": "%URL%",
         "pass": "%WORKER_NAME%",
         "template": "%WAL%",
-        "user_config": ""
+        "user_config": "--xelis-solo"
       }
     }
   }


### PR DESCRIPTION
OneZeroMiner v1.3.3 has broken XelPool support by default, an additional command-line flag is required to make it work. This commit adds that command-line flag.