### PR TITLE
Add Qverse Pool for QTC (Qubitcoin)

### DIFF
--- a/pool_templates/qversepool.json
+++ b/pool_templates/qversepool.json
@@ -1,0 +1,33 @@
+{
+    "name": "Qverse Pool",
+    "url": "https://pool.qverse.pro",
+    "logo": "https://pool.qverse.pro/logo-dark.png",
+    "fee": "0%",
+    "coins": {
+        "QTC": {
+            "coin": "QTC",
+            "servers": [
+                {
+                    "geo": "Cloudflare BOOST",
+                    "urls": [
+                        "stratum.qverse.pro:25565"
+                    ]
+                }
+            ],
+            "miners": {
+                "onezerominer": {
+                    "url": "%URL%",
+                    "algo": "qhash",
+                    "template": "%WAL%.%WORKER_NAME%",
+                    "pass": "x"
+                },
+                "wildrig-multi": {
+                    "url": "stratum+tcp://%URL%",
+                    "algo": "qhash",
+                    "template": "%WAL%.%WORKER_NAME%",
+                    "pass": "x"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## New Pool Addition

**Pool Name:** Qverse Pool
**Website:** https://pool.qverse.pro
**Coin:** QTC (Qubitcoin)
**Algorithm:** qhash
**Fee:** 0% (free for the first 3 months)

### Supported Miners:
- onezerominer
- wildrig-multi

### Server:
- Cloudflare BOOST (Global CDN)
- stratum.qverse.pro:25565

Thank you for reviewing.