### PR TITLE
Add Kuradisia unified pool template

### DIFF
--- a/pool_templates/kuradisia.json
+++ b/pool_templates/kuradisia.json
@@ -17,8 +17,11 @@
         ]
       }
     ],
-     "miners": {
-      "for_asic": true
+    "miners": {
+      "asicminer": {
+        "url": "stratum+tcp://%URL%",
+        "template": "%WAL%.%WORKER_NAME%"
+      }
     }
   },
   {


### PR DESCRIPTION
This PR adds a unified Kuradisia pool template (kuradisia.json)
including LTC, XMR, RTM, PHI, and MEWC.

As requested, all coin templates have been merged into a single file.

Old coin-specific templates were removed accordingly.
