### PR TITLE
kryptex: QUAI pool update. ProgPow replaced with KawPow

### DIFF
--- a/pool_templates/kryptex.json
+++ b/pool_templates/kryptex.json
@@ -1161,71 +1161,103 @@
             {
                 "geo": "Global",
                 "urls": [
-                    "quai.kryptex.network:7035"
+                    "quai-kawpow-kawpow.kryptex.network:7043"
                 ],
                 "ssl_urls": [
-                    "quai.kryptex.network:8035"
+                    "quai-kawpow.kryptex.network:8043"
                 ]
             },
             {
                 "geo": "EU",
                 "urls": [
-                    "quai-eu.kryptex.network:7035"
+                    "quai-kawpow-eu.kryptex.network:7043"
                 ],
                 "ssl_urls": [
-                    "quai-eu.kryptex.network:8035"
+                    "quai-kawpow-eu.kryptex.network:8043"
                 ]
             },
             {
                 "geo": "USA",
                 "urls": [
-                    "quai-us.kryptex.network:7035"
+                    "quai-kawpow-us.kryptex.network:7043"
                 ],
                 "ssl_urls": [
-                    "quai-us.kryptex.network:8035"
+                    "quai-kawpow-us.kryptex.network:8043"
                 ]
             },
             {
                 "geo": "Asia",
                 "urls": [
-                    "quai-sg.kryptex.network:7035"
+                    "quai-kawpow-sg.kryptex.network:7043"
                 ],
                 "ssl_urls": [
-                    "quai-sg.kryptex.network:8035"
+                    "quai-kawpow-sg.kryptex.network:8043"
                 ]
             },
             {
                 "geo": "RU",
                 "urls": [
-                    "quai-ru.kryptex.network:7035"
+                    "quai-kawpow-ru.kryptex.network:7043"
                 ],
                 "ssl_urls": [
-                    "quai-ru.kryptex.network:8035"
+                    "quai-kawpow-ru.kryptex.network:8043"
                 ]
             }
         ],
         "miners": {
-            "_prototype": "miners_progpow_quai",
+            "_prototype": "miners_kawpow",
             "rigel": {
-                "algo": "quai",
+                "algo": "kawpow",
                 "url": "%URL%",
                 "pass": "x",
                 "template": "%WAL%.%WORKER_NAME%",
-                "user_config": "-a quai"
+                "user_config": "--coin quai"
             },
             "srbminer": {
-                "algo": "progpow_quai",
+                "algo": "kawpow",
+                "url": "%URL%",
+                "pass": "x",
+                "template": "%WAL%.%WORKER_NAME%",
+                "user_config": "--disable-cpu"
+            },
+            "wildrig": {
+                "algo": "kawpow",
                 "url": "%URL%",
                 "pass": "x",
                 "template": "%WAL%.%WORKER_NAME%",
                 "user_config": ""
             },
-            "wildrig": {
-                "algo": "progpow-quai",
-                "url": "%URL%",
+            "nbminer":{
+                "url":"%URL%",
+                "pass":"x",
+                "template":"%WAL%.%WORKER_NAME%",
+                "algo":"kawpow"
+            },
+            "gminer":{
+                "algo":"kawpow",
+                "server":"%URL_HOST%",
+                "port":"%URL_PORT%",
+                "pass":"x",
+                "template":"%WAL%.%WORKER_NAME%"
+            },
+            "teamredminer": {
+                "url": "stratum+tcp:\/\/%URL%",
+                "algo": "kawpow",
+                "pass": "x",
+                "template": "%WAL%.%WORKER_NAME%"
+            },
+            "wildrig-multi": {
+                "url": "stratum+tcp:\/\/%URL%",
+                "algo": "kawpow",
                 "pass": "x",
                 "template": "%WAL%.%WORKER_NAME%",
                 "user_config": ""
+            },
+            "bzminer": {
+                "url": "%URL%",
+                "algo": "kawpow",
+                "template": "%WAL%",
+                "worker": "%WORKER_NAME%"
             }
         }
     },


### PR DESCRIPTION
Dear Hive Team, please accept this update:

- QUAI ProgPow replaced with KawPow
- QUAI Pool Address list update
- QUAI KawPow templates added