### PR TITLE
Add BowserLab pool configuration JSON file

### DIFF
--- a/pool_templates/BowserLab.json
+++ b/pool_templates/BowserLab.json
@@ -1,0 +1,28 @@
+[
+  {
+    "pool": {
+      "name": "BowserLab",
+      "url": "http://bowserlab.ddns.net",
+      "fee": 1,
+      "type": "PROP"
+    }
+  },
+  {
+    "coin": "PEPEW",
+    "servers": [
+      {
+        "geo": "Europe",
+        "urls": [
+          "bowserlab.ddns.net:9912"
+        ]
+      }
+    ],
+    "miners": {
+      "custom": {
+        "url": "stratum+tcp://%URL%",
+        "template": "%WAL%",
+        "pass": "c=PEPEW"
+      }
+    }
+  }
+]


### PR DESCRIPTION
This PR adds BowserLab PEPEW mining pool to HiveOS.

Pool:
http://bowserlab.ddns.net

Coin:
PEPEW

Algorithm:
HooHash V110

Stratum:
bowserlab.ddns.net:9912

Password:
c=PEPEW

Pool fee:
1%

Reward type:
PROP