### PR TITLE
Remove 'xelishashv2_pepew' from miner algorithms

### DIFF
--- a/miners/srbminer.json
+++ b/miners/srbminer.json
@@ -152,7 +152,6 @@
       "xdag",
       "xehash",
       "xelishash",
-      "xelishashv2_pepew",
       "xelishashv2",
       "xelishashv3",
       "xhash"


### PR DESCRIPTION
PepePow (PEPEW) has migrated from the legacy xelishashv2_pepew algorithm to the new HooHash V110 algorithm.

This change removes the obsolete xelishashv2_pepew algorithm entry from SRBMiner configuration to prevent user confusion.

Current PepePow (PEPEW) algorithm:
HooHash V110

Official website:
https://pepepow.org/

Official miners:
https://htn.foztor.net/