### PR TITLE
Move PEPEW coin from XelisHashV2 to HooHash

### DIFF
--- a/algos.json
+++ b/algos.json
@@ -2756,12 +2756,13 @@
         ]
     },
 
-    {
-        "name": "hoohash",
-        "coins": [
-            "HTN"
-        ]
-    },
+  {
+    "name": "hoohash",
+    "coins": [
+        "PEPEW",
+        "HTN"
+    ]
+},
 
     {
         "name": "walahash",
@@ -2939,14 +2940,6 @@
         "coins": [
             "SKF",
             "ZTX"
-        ]
-    },
-
-    {
-        "name": "xelishashv2",
-        "coins": [
-            "PEPEW",
-            "Nicehash-XelisHashV2"
         ]
     },
 


### PR DESCRIPTION
PepePow (PEPEW) no longer uses XelisHashV2.

The network has migrated to the HooHash V110 algorithm.

Updated algorithm mapping:
PEPEW -> hoohash

Official website:
https://pepepow.org/

Official miners:
https://htn.foztor.net/