### PR TITLE
Add CS (Cloud Service) coin to equihash 125/4 algorithm

### DIFF
--- a/algos.json
+++ b/algos.json
@@ -1862,6 +1862,7 @@
         "name": "equihash 125\/4",
         "coins": [
             "FLUX",
+            "CS",
             "Nicehash-ZelHash",
             "Zpool-equihash125",
             "K1Pool-Equihash125"


### PR DESCRIPTION
## Summary
- Registers the `CS` (Cloud Service) coin ticker under the existing `equihash 125/4` (ZelHash) algorithm entry in `algos.json`, alongside `FLUX`.

## About the coin
- CS Cloud Service — decentralized cloud computing network
- Consensus: ZelHash (Equihash 125,4), ASIC-resistant, ~1.3GB VRAM
- Block time: 2 min, LWMA3; emission 150 CS → 2 halvings → permanent floor of 37.5 CS, 0% premine
- 4 "CS Node" tiers (PROTON/ELETRON/NEUTRON/FOTON) hosting real workloads (AI/ML, hosting, DBs, containers, domains)
- Site: cscloudservice.com

Part of a 3-PR set adding Cloud Service (CS) support:
1. This PR — register the coin/algorithm.
2. cs-miner miner definition — https://github.com/minershive/hive-pooltemplates/pull/1843
3. `miningtothelastblock.top` pool template update to mine CS — https://github.com/minershive/hive-pooltemplates/pull/1844