### PR TITLE
Add cs-miner miner definition

### DIFF
--- a/miners/cs-miner.json
+++ b/miners/cs-miner.json
@@ -1,0 +1,21 @@
+{
+    "full_name": "CS-Miner",
+    "for_amd": true,
+    "for_nvidia": true,
+    "for_cpu": false,
+    "for_asic": false,
+    "for_intel": false,
+    "dual": false,
+    "ssl_prefix": "",
+    "default_algo": "zelhash",
+    "default_fork": null,
+    "default_units": "khs",
+    "algos": [
+        "zelhash"
+    ],
+    "dalgos": [],
+    "algomap": {
+        "zelhash": "equihash 125\/4"
+    },
+    "forks": []
+}


### PR DESCRIPTION
## Summary
- Adds `miners/cs-miner.json`: metadata for cs-miner (GPU AMD/Nvidia, OpenCL, ZelHash/`equihash 125/4`).
- cs-miner ships as a HiveOS "Custom miner" package (`CUSTOM_NAME=cs-miner` in its `h-manifest.conf`), so it is actually launched via the `"custom"` miner key in pool templates (see the `miningtothelastblock.top` pool template PR) rather than by this file's id directly — this file documents its capabilities/algo mapping (`zelhash` -> `equihash 125/4`, matching the existing mapping already present in `miners/custom.json`).

## ⚠️ Reviewer note
The cs-miner binary (https://github.com/MauricioSpagnol/cs-miner-releases) source (https://github.com/MauricioSpagnol/cs-miner) bundles an **opt-out** "OPoI" AI-inference feature. By default (unless `--no-opoi` is passed in the Flight Sheet's Miner config field) it will:
- Download and run Ollama's install script via `curl -fsSL https://ollama.com/install.sh | sh`
- Install/start a local Ollama server via systemd
- On low-RAM rigs, create a 4GB swapfile and edit `/etc/fstab`

Flagging this explicitly so maintainers/miners are aware of this behavior before merging/deploying.

Part of a 3-PR set adding Cloud Service (CS) support (see companion PRs for the coin/algorithm registration and the `miningtothelastblock.top` pool template update).