### PR TITLE
Add qubic.li pool template for QUBIC

### DIFF
--- a/pool_templates/qubicli.json
+++ b/pool_templates/qubicli.json
@@ -1,0 +1,32 @@
+[
+	{
+		"pool": {
+			"name": "qubic.li",
+			"url": "https://platform.qubic.li"
+		}
+	},
+	{
+		"coin": "QUBIC",
+		"servers": [
+			{
+				"geo": "Global",
+				"urls": [
+					"wps.qubic.li:443"
+				],
+				"ssl_urls": [
+					"wps.qubic.li:443"
+				]
+			}
+		],
+		"miners": {
+			"custom": {
+				"url": "wss://wps.qubic.li/ws",
+				"algo": "qubic",
+				"miner": "qubminer",
+				"template": "%WAL%-%WORKER_NAME%",
+				"install_url": "https://github.com/qubic-li/hiveos/releases/download/latest/qubminer-latest.tar.gz",
+				"user_config": "\"accessToken\":\"YOUROWNTOKEN\"\nAutoUpdate"
+			}
+		}
+	}
+]


### PR DESCRIPTION
qubic.li (platform.qubic.li / wps.qubic.li) is one of the original QUBIC mining pools -- QLI has run Qubic infrastructure (nodes, mining pool, AI-training-as-mining) since early in the network's life, alongside its own official HiveOS custom-miner package (github.com/qubic-li/hiveos).

This adds qubic.li as a third option.

install_url points at qubic-li/hiveos's stable release tarball (qubminer-latest.tar.gz), which wraps the official qli-Client binary (github.com/qubic-li/client). Pool address confirmed from that repo's own README/appsettings_global.json: wss://wps.qubic.li/ws.