### PR TITLE
Remove DERO from miningtothelastblock.top pool

### DIFF
--- a/pool_templates/miningtothelastblock.json
+++ b/pool_templates/miningtothelastblock.json
@@ -5,42 +5,5 @@
       "url": "https://miningtothelastblock.top",
       "type": "PPLNS SOLO"
     }
-  },
-  {
-    "coin": "DERO",
-    "servers": [
-      {
-        "geo": "Global Native WSS",
-        "urls": [
-          "dero.miningtothelastblock.top:4000"
-        ]
-      },
-      {
-        "geo": "Global Low Diff",
-        "urls": [
-          "dero.miningtothelastblock.top:3333"
-        ]
-      },
-      {
-        "geo": "Global Med Diff",
-        "urls": [
-          "dero.miningtothelastblock.top:5555"
-        ]
-      },
-      {
-        "geo": "Global High Diff",
-        "urls": [
-          "dero.miningtothelastblock.top:7777"
-        ]
-      }
-    ],
-    "miners": {
-      "_prototype": "miners_astrobwt",
-      "custom": {
-        "url": "%URL%",
-        "template": "%WAL%.%WORKER_NAME%",
-        "pass": "x"
-      }
-    }
   }
 ]


### PR DESCRIPTION
## Summary
- The miningtothelastblock.top pool no longer supports DERO mining, so this removes the DERO coin entry from its template.

## Test plan
- [x] Validated `pool_templates/miningtothelastblock.json` is valid JSON